### PR TITLE
Add an alias to start tmuxinator in Gitpod

### DIFF
--- a/private_dot_config/bash/alias.bash
+++ b/private_dot_config/bash/alias.bash
@@ -22,3 +22,6 @@ alias gco='git checkout'
 alias gg='git grep'
 alias gst='git diff master --compact-summary'
 alias gca='git commit --amend'
+
+# Devenv
+alias devenv='tmuxinator start -p gitpod/.tmuxinator.yml'


### PR DESCRIPTION
We can start a `tmuxinator` session with all terminals configured in Gitpod.

With this, we can have a quite similar experience as the devenvs