### PR TITLE
Lock catpuccin version

### DIFF
--- a/private_dot_config/nvim/lua/plugins.lua
+++ b/private_dot_config/nvim/lua/plugins.lua
@@ -169,6 +169,7 @@ return require("packer").startup(function(use)
 		config = function()
 			require("plugins/catppuccin")
 		end,
+		commit = "7f718802b63de7badb3fec3150b345bb6b7674bb",
 	})
 
   -- Colorize hex values


### PR DESCRIPTION
They're changing the API and it's breaking stuff, so we'd better lock the version to a known working one.