### PR TITLE
Fast fuzzy find with space space

### DIFF
--- a/private_dot_config/nvim/lua/plugins/which-key.lua
+++ b/private_dot_config/nvim/lua/plugins/which-key.lua
@@ -53,10 +53,15 @@ vim.keymap.set("n", "<Leader>f", ":NvimTreeFindFile<CR>", { silent = true })
 -- No Highlights
 vim.keymap.set("n", "<Leader>h", ":let @/=''<CR>", { silent = true })
 
+-- Fast fuzzy find
+vim.keymap.set("n", "<Leader><Leader>", "<cmd>FzfLua git_files<cr>", { silent = true })
+
 local mappings = {
 	n = "NerdTree",
 	f = "Find File",
 	h = "No Highlight",
+
+	["<space>"] = "Fuzzy search",
 
 	g = {
 		name = "Git",


### PR DESCRIPTION
Super fast access to a fuzzy finder for only Git files with `<leader><leader>`.