### PR TITLE
Disable snippets

### DIFF
--- a/private_dot_config/nvim/lua/plugins.lua
+++ b/private_dot_config/nvim/lua/plugins.lua
@@ -81,13 +81,7 @@ return require("packer").startup(function(use)
 	use({ "hrsh7th/cmp-path" })
 	use({ "hrsh7th/cmp-nvim-lsp" })
 	use({ "hrsh7th/cmp-buffer" })
-	use({ "hrsh7th/cmp-vsnip" })
 	use({ "onsails/lspkind-nvim" })
-
-	-- Snippets
-	use({ "hrsh7th/vim-vsnip" })
-	use({ "hrsh7th/vim-vsnip-integ" })
-	use({ "rafamadriz/friendly-snippets" })
 
 	-- Treesitter
 	use({
@@ -171,14 +165,14 @@ return require("packer").startup(function(use)
 		end,
 	})
 
-  -- Colorize hex values
-  use("ap/vim-css-color")
+	-- Colorize hex values
+	use("ap/vim-css-color")
 
-  -- Modify faster (){}[] contents
-  use("wellle/targets.vim")
+	-- Modify faster (){}[] contents
+	use("wellle/targets.vim")
 
-  -- Find and replace
-  use("nvim-pack/nvim-spectre")
+	-- Find and replace
+	use("nvim-pack/nvim-spectre")
 
 	-- Status Line
 	use({

--- a/private_dot_config/nvim/lua/plugins/nvim-cmp.lua
+++ b/private_dot_config/nvim/lua/plugins/nvim-cmp.lua
@@ -17,8 +17,7 @@ cmp.setup({
 			menu = {
 				buffer = "[Buffer]",
 				nvim_lsp = "[LSP]",
-				vsnip = "[Vsnip]",
-        path = "[Path]",
+				path = "[Path]",
 			},
 		}),
 	},
@@ -33,12 +32,6 @@ cmp.setup({
 	experimental = {
 		ghost_text = false,
 	},
-	snippet = {
-		-- REQUIRED - you must specify a snippet engine
-		expand = function(args)
-			vim.fn["vsnip#anonymous"](args.body) -- For `vsnip` users.
-		end,
-	},
 	mapping = {
 		["<C-b>"] = cmp.mapping(cmp.mapping.scroll_docs(-4), { "i", "c" }),
 		["<C-f>"] = cmp.mapping(cmp.mapping.scroll_docs(4), { "i", "c" }),
@@ -52,8 +45,6 @@ cmp.setup({
 		["<Tab>"] = cmp.mapping(function(fallback)
 			if cmp.visible() then
 				cmp.select_next_item()
-			elseif vim.fn["vsnip#available"](1) == 1 then
-				feedkey("<Plug>(vsnip-expand-or-jump)", "")
 			elseif has_words_before() then
 				cmp.complete()
 			else
@@ -64,15 +55,12 @@ cmp.setup({
 		["<S-Tab>"] = cmp.mapping(function()
 			if cmp.visible() then
 				cmp.select_prev_item()
-			elseif vim.fn["vsnip#jumpable"](-1) == 1 then
-				feedkey("<Plug>(vsnip-jump-prev)", "")
 			end
 		end, { "i", "s" }),
 	},
 	sources = cmp.config.sources({
-		{ name = "vsnip", priority = 9999 },
 		{ name = "nvim_lsp" },
 		{ name = "buffer" },
-    { name = "path" },
+		{ name = "path" },
 	}),
 })


### PR DESCRIPTION
This one is controversial and I will understand if you don't want to
merge it (I will branch if that's the case).

I hate snippets. I never use them and they get in my way. Maybe they are
wrongly configured, but the amount of times that I get snippets when I
don't want them is just a waste of time.

Examples:
  - Sometimes I want to move from `{}` to `do/end` and when I place the
    cursor on `{` and type `do<Enter>` I automatically get an annoying
    `end` that I have to delete imediately.
  - Sometimes I want to press `<Enter>` after a `{` and it will add
    ruby block parameters for no reason.

Do you use them? How do you workaround things getting in the middle when
you don't want them? It screws up my muscle memory.