### PR TITLE
Disable tpm

### DIFF
--- a/dot_tmux.conf
+++ b/dot_tmux.conf
@@ -140,11 +140,10 @@ setw -g mode-style "fg=${thm_pink} bg=${thm_black4} bold"
 
 # List of plugins
 # =================
-set -g @plugin 'tmux-plugins/tpm'               # Tmux plugin manager
-set -g @plugin 'tmux-plugins/tmux-sensible'     # TODO: Document
+# set -g @plugin 'tmux-plugins/tpm'               # Tmux plugin manager
+# set -g @plugin 'tmux-plugins/tmux-sensible'     # TODO: Document
 # set -g @plugin 'christoomey/vim-tmux-navigator' # Awesome navigation between vim and tmux
 # set -g @plugin 'tmux-plugins/tmux-copycat'      # Search using `prefix + /`
 # set -g @plugin 'tmux-plugins/tmux-open'         # Opens files highlighted using `o`
 # set -g @plugin 'tmux-plugins/tmux-yank'         # Yanks with `y`
-
-run -b '~/.tmux/plugins/tpm/tpm'
+# run -b '~/.tmux/plugins/tpm/tpm'


### PR DESCRIPTION
We are not using any plugin, so let's disable them and get rid of the
error we get every time we turn on Gitpod.