### PR TITLE
Change key bindings for cmp

### DIFF
--- a/private_dot_config/nvim/lua/plugins/nvim-cmp.lua
+++ b/private_dot_config/nvim/lua/plugins/nvim-cmp.lua
@@ -24,7 +24,7 @@ cmp.setup({
     },
     mapping = {
         ["<CR>"] = cmp.mapping.confirm({ select = true }),
-        ["<C-n>"] = cmp.mapping(function(fallback)
+        ["<C-j>"] = cmp.mapping(function(fallback)
             if cmp.visible() then
                 cmp.select_next_item()
             elseif luasnip.expand_or_jumpable() then
@@ -33,7 +33,7 @@ cmp.setup({
                 fallback()
             end
         end, { "i", "s" }),
-        ["<C-p>"] = cmp.mapping(function(fallback)
+        ["<C-k>"] = cmp.mapping(function(fallback)
             if cmp.visible() then
                 cmp.select_prev_item()
             elseif luasnip.jumpable(-1) then


### PR DESCRIPTION
Change key bindings for next and previous suggestions. Instead of `ctrl+n` and `ctrl+p`, I think it is more natural to have `ctrl+j` and `ctrl+k`