### PR TITLE
Use `lua_ls` instead of deprecated `sumneko_lua`

### DIFF
--- a/private_dot_config/nvim/lua/lsp/clients/lua_ls.lua
+++ b/private_dot_config/nvim/lua/lsp/clients/lua_ls.lua
@@ -2,7 +2,7 @@ local M = {}
 local lspconfig = require("lspconfig")
 
 M.setup = function(on_attach, capabilities)
-  lspconfig.sumneko_lua.setup({
+  lspconfig.lua_ls.setup({
     on_attach = on_attach,
     capabilities = capabilities,
     settings = {

--- a/private_dot_config/nvim/lua/lsp/init.lua
+++ b/private_dot_config/nvim/lua/lsp/init.lua
@@ -53,7 +53,7 @@ local servers = {
   "eslint",
   "sorbet",
   "solargraph",
-  "sumneko_lua",
+  "lua_ls",
   "null-ls",
 }
 

--- a/private_dot_config/nvim/lua/plugins/mason.lua
+++ b/private_dot_config/nvim/lua/plugins/mason.lua
@@ -1,4 +1,4 @@
 require("mason").setup()
 require("mason-lspconfig").setup({
-    ensure_installed = { "sumneko_lua", "solargraph" }
+    ensure_installed = { "lua_ls", "solargraph" }
 })


### PR DESCRIPTION
Check https://github.com/neovim/nvim-lspconfig/pull/2439

This is the warning:

![Screenshot 2023-02-22 at 11 43 15](https://user-images.githubusercontent.com/4289392/220600363-74b2cce8-b22b-4899-9092-c13f2b60e4dd.png)
