### PR TITLE
Remove incompatible key mappings in nvim-tree

### DIFF
--- a/private_dot_config/nvim/lua/plugins/nvim-tree.lua
+++ b/private_dot_config/nvim/lua/plugins/nvim-tree.lua
@@ -2,15 +2,6 @@ local colors = require("catppuccin.palettes").get_palette()
 vim.cmd("highlight NvimTreeGitNew gui=NONE guifg=" .. colors.green .. " guibg=NONE")
 
 require("nvim-tree").setup({
-  view = {
-    mappings = {
-      list = {
-        { key = "s", action = "vsplit" },
-        { key = "i", action = "split" },
-        { key = "p", action = "parent_node" },
-      },
-    },
-  },
   renderer = {
     indent_markers = {
       enable = true,


### PR DESCRIPTION
A few days ago, `nvim-tree` removed this configuration option, here:

https://github.com/nvim-tree/nvim-tree.lua/pull/2371

We need to remap them. For now, I just remove them.